### PR TITLE
chore(trunk): stop tracking machine-specific .trunk/logs symlink

### DIFF
--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -1,2 +1,3 @@
 *out
 external
+logs

--- a/.trunk/logs
+++ b/.trunk/logs
@@ -1,1 +1,0 @@
-/home/sall/.cache/trunk/repos/d885afbe90cd998a3d34940ae6f54739/logs


### PR DESCRIPTION
`.trunk/logs` was committed as a symlink to a per-user cache path (`/home/<user>/.cache/trunk/...`). That violates the no-personal-paths rule and shows as a spurious type-change on every other machine/checkout.

This untracks it (`git rm --cached`) and adds `logs` to `.trunk/.gitignore` so trunk continues to manage the symlink locally without tracking it.

No functional change to the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)