### PR TITLE
ci(manifest): add lint workflow; prune ancient Zsh 5.1.1/5.2.4

### DIFF
--- a/.github/workflows/manifest-lint.yml
+++ b/.github/workflows/manifest-lint.yml
@@ -1,0 +1,35 @@
+name: Manifest Lint
+
+on:
+  push:
+    branches: ["main", "next"]
+    paths:
+      - "package.json"
+      - "scripts/build-manifest.py"
+  pull_request:
+    paths:
+      - "package.json"
+      - "scripts/build-manifest.py"
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Validate package.json parses
+        run: |
+          jq . package.json > /dev/null
+
+      - name: Validate zsh-data structure and default profile
+        run: |
+          jq -e '.["zsh-data"]["plugin-info"]["plugin"] == "zsh"' package.json > /dev/null
+          jq -e '.["zsh-data"]["zi-ices"]["default"]["atclone"] | length > 0' package.json > /dev/null
+
+      - name: Ensure manifest is up-to-date with generator script
+        run: |
+          python3 scripts/build-manifest.py
+          git diff --exit-code package.json || (echo "package.json is out of date. Please run scripts/build-manifest.py and commit the result." && exit 1)

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,8 +42,6 @@ zi pack"5.6.2" for zsh
 zi pack"5.5.1" for zsh
 zi pack"5.4.2" for zsh
 zi pack"5.3.1" for zsh
-zi pack"5.2.4" for zsh
-zi pack"5.1.1" for zsh
 ```
 
 ### System installation (opt-in)

--- a/package.json
+++ b/package.json
@@ -27,28 +27,6 @@
         "nocompletions": "",
         "countdown": ""
       },
-      "5.1.1": {
-        "requires": "cc;make;cp;rm",
-        "git": "",
-        "lucid": "",
-        "as": "null",
-        "atclone": "git checkout --quiet zsh-5.1.1; ./.preconfig; m {nl}{hi}Building Zsh{…}; CPPFLAGS='-I/usr/include -I/usr/local/include' CFLAGS='-g -O2 -Wall' LDFLAGS='-L/usr/lib -L/usr/local/lib' ./configure --prefix=\"$ZPFX\" >> /dev/null 2>&1 && { type yodl >> /dev/null 2>&1 || { m -u2 {warn}WARNING{ehi}:{rst}{warn} No {cmd}yodl{warn}, manual pages will not be built.; ((0)); } && { make install; ((1)); } || make install.bin install.fns install.modules } >> /dev/null 2>&1 && { [[ ${ZSH_INSTALL_SYSTEM:-} != 1 ]] || { type sudo >> /dev/null 2>&1 && [[ -e /bin/zsh ]] && [[ ! -e /bin/zsh.bkp ]] && sudo mv /bin/zsh /bin/zsh.bkp && sudo cp -vf Src/zsh /bin/zsh; }; } && m {ok}The build succeeded. || m {failure}The build failed.",
-        "atpull": "%atclone",
-        "nocompile": "",
-        "nocompletions": "",
-        "countdown": ""
-      },
-      "5.2.4": {
-        "requires": "cc;make;cp;rm",
-        "git": "",
-        "lucid": "",
-        "as": "null",
-        "atclone": "git checkout --quiet zsh-5.2.4; ./.preconfig; m {nl}{hi}Building Zsh{…}; CPPFLAGS='-I/usr/include -I/usr/local/include' CFLAGS='-g -O2 -Wall' LDFLAGS='-L/usr/lib -L/usr/local/lib' ./configure --prefix=\"$ZPFX\" >> /dev/null 2>&1 && { type yodl >> /dev/null 2>&1 || { m -u2 {warn}WARNING{ehi}:{rst}{warn} No {cmd}yodl{warn}, manual pages will not be built.; ((0)); } && { make install; ((1)); } || make install.bin install.fns install.modules } >> /dev/null 2>&1 && { [[ ${ZSH_INSTALL_SYSTEM:-} != 1 ]] || { type sudo >> /dev/null 2>&1 && [[ -e /bin/zsh ]] && [[ ! -e /bin/zsh.bkp ]] && sudo mv /bin/zsh /bin/zsh.bkp && sudo cp -vf Src/zsh /bin/zsh; }; } && m {ok}The build succeeded. || m {failure}The build failed.",
-        "atpull": "%atclone",
-        "nocompile": "",
-        "nocompletions": "",
-        "countdown": ""
-      },
       "5.3.1": {
         "requires": "cc;make;cp;rm",
         "git": "",

--- a/scripts/build-manifest.py
+++ b/scripts/build-manifest.py
@@ -28,7 +28,7 @@ METADATA = {
 PLUGIN_INFO = {"user": "zsh-users", "plugin": "zsh"}
 
 # Selectable version profiles, in addition to the unpinned "default".
-VERSIONS = ["5.1.1", "5.2.4", "5.3.1", "5.4.2", "5.5.1", "5.6.2",
+VERSIONS = ["5.3.1", "5.4.2", "5.5.1", "5.6.2",
             "5.7.1", "5.8", "5.8.1", "5.9"]
 
 # Single source of truth for the build recipe. `{checkout}` is replaced per


### PR DESCRIPTION
Salvages the still-relevant parts of the stale `feature-zsh13-manifest-dedup` branch. The branch's `/bin/zsh` opt-in + manifest-dedup work was already merged (and hardened further) in `d4e92dd` ("Closes ZSH-13"), so only the genuinely-new pieces are brought forward here, rebuilt on top of current `main`:

**1. Manifest lint workflow** (`ci(manifest)`)
- Validates `package.json` parses and has the expected `zsh-data` structure.
- Fails CI if `package.json` drifts from `scripts/build-manifest.py` output.
- Action pinned to a full commit SHA per workspace policy.

**2. Prune ancient Zsh versions** (`build(package)`)
- Drop `5.1.1` and `5.2.4` from the generator's `VERSIONS`; regenerate `package.json` (default + 8 versions); trim matching README examples.

Verified locally: all three workflow steps pass, `package.json` is stable on re-run, valid JSON, and the safer `/bin/zsh` install guards from `main` (`!= 1` + refuse-clobber `/bin/zsh.bkp`) are preserved — no safety regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)